### PR TITLE
Sunset prompt-only review references

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -48,7 +48,7 @@ Prefer a package manager or a verified binary over piping a remote script to a s
    - Check for related configuration files
 
 2. **Run CodeRabbit Review**
-   - Execute `coderabbit review --plain` to get structured review output
+   - Execute `coderabbit review --agent` to get structured review output
    - Parse and categorize findings by severity and type
 
 3. **Analyze Findings**
@@ -62,7 +62,7 @@ Prefer a package manager or a verified binary over piping a remote script to a s
    - Highlight positive aspects of the code
 
 5. **Interactive Resolution**
-   - Offer to apply automated fixes using `coderabbit review --prompt-only`
+   - Use `coderabbit review --agent` findings as the primary fix workflow
    - Explain complex issues in detail
    - Help implement suggested changes
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -51,7 +51,7 @@ Once prerequisites are met:
 
 ```bash
 # type defaults to "all"; add --base only when specified
-coderabbit review --plain -t "${type:-all}" ${base:+--base "$base"}
+coderabbit review --agent -t "${type:-all}" ${base:+--base "$base"}
 ```
 
 Where `type` and `base` come from `$ARGUMENTS`:
@@ -66,8 +66,8 @@ Add `--base <branch>` only when a base branch is specified.
 
 Group findings by severity:
 
-1. **Critical** - Security, bugs
-2. **Suggestions** - Improvements
-3. **Positive** - What's good
+1. **Critical** - Security vulnerabilities, data loss risks, crashes
+2. **Warning** - Bugs, performance issues, anti-patterns
+3. **Info** - Style issues, suggestions, minor improvements
 
-Offer to apply fixes if `codegenInstructions` are present.
+Offer to apply fixes from the `--agent` findings when the output includes actionable remediation details.


### PR DESCRIPTION
## Summary
- switch the Claude code-review agent doc to coderabbit review --agent
- switch the Claude review command doc to use --agent as the primary review path
- align the command severity/result guidance with the structured --agent output

## Testing
- not run (docs/prompt changes only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code review workflow to agent-based analysis
  * Refined severity categories: Critical now includes security vulnerabilities and data loss risks
  * Replaced "Suggestions/Positive" with "Warning" and "Info" categories
  * Updated fix recommendation process with enhanced remediation details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->