### PR TITLE
Repo polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.claude/settings.local.json
+.venv/
+.venv-*/
+node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this repository are documented in this file.
 
+## Unreleased
+
+### Added
+
+- Added `name` frontmatter to the Claude Code `code-reviewer` subagent.
+- Added a repository `.gitignore` for local Claude settings, virtualenvs, and
+  dependency directories.
+
+### Changed
+
+- Reframed the README as the canonical home for CodeRabbit skills and plugin
+  packaging across supported agents.
+- Removed public README guidance for tagged release archives while that channel
+  remains in development.
+- Marked the tagged release archive channel as in development in
+  `DISTRIBUTION_CHANNELS.md`.
+- Quoted Claude Code command frontmatter values so standard YAML parsers can
+  validate them.
+
 ## [1.1.1] - 2026-04-22
 
 ### Added

--- a/DISTRIBUTION_CHANNELS.md
+++ b/DISTRIBUTION_CHANNELS.md
@@ -1,16 +1,16 @@
 # Distribution Channels
 
-Last verified: 2026-04-22
+Last verified: 2026-04-28
 
-This file is the repository's operating inventory for where CodeRabbit skills and adjacent agent integrations are distributed. Update it whenever a channel is launched, deprecated, moved, or repackaged.
+This file is the repository's operating inventory for where CodeRabbit skills and adjacent agent integrations are distributed. Public user-facing install guidance belongs in `README.md`; in-development and maintainer-only channels should stay here until they are ready to launch.
 
 ## Channels
 
 | Channel | Status | Source of truth | Notes |
 | --- | --- | --- | --- |
 | Skills package (`npx skills add coderabbitai/skills`) | Live | `README.md`, `skills/` | Canonical multi-agent distribution path for 35+ skills-compatible agents. |
-| Tagged GitHub release archive for binary installers | Repo-configured, publish on `v*` tag push | `.github/workflows/release.yml`, `README.md` | Publishes a versioned tarball, SHA-256 file, and release manifest; consumers should pin tags and reject checksum mismatch. |
-| Claude Code plugin marketplace | Live | `.claude-plugin/plugin.json`, `commands/`, `agents/` | In-repo packaging is active and documented. |
+| Tagged GitHub release archive for binary installers | In development, not user-facing | `.github/workflows/release.yml` | Workflow publishes a versioned tarball, SHA-256 file, and release manifest on `v*` tags, but this channel is not part of public install guidance yet. |
+| Claude Code plugin marketplace | Live, source migration pending | `.claude-plugin/plugin.json`, `commands/`, `agents/` | In-repo packaging is active; official marketplace source is being moved from `coderabbitai/claude-plugin` to this repository. |
 | Cursor native plugin marketplace | Repo-packaged, publication should be verified | `.cursor-plugin/plugin.json` | Repo contains marketplace manifest; treat public listing as separate verification work. |
 | Codex plugin marketplace | Live, separate repo | CodeRabbit docs + `coderabbitai/codex-plugin` | Not packaged from this repository today. |
 | VS Code / Cursor / Windsurf IDE extension | Live, separate distribution | CodeRabbit IDE extension docs | Complements skills; not a replacement for `SKILL.md` installs. |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# CodeRabbit Skills
+# CodeRabbit Skills and Plugins
 
 ![Version](https://img.shields.io/badge/version-1.1.1-blue)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Agents](https://img.shields.io/badge/works_with-35%2B_agents-brightgreen)](#supported-agents)
 
-AI-powered code review for 35+ coding agents, powered by [CodeRabbit](https://coderabbit.ai). Detect bugs, security issues, and quality risks before you merge.
+The canonical home for CodeRabbit's agent-native skills and plugin packaging.
+Use it to install AI-powered code review into 35+ coding agents, Claude Code,
+Cursor, and other supported agent environments.
+
+CodeRabbit detects bugs, security issues, and quality risks before you merge.
 
 ## Quickstart
 
@@ -19,17 +23,19 @@ Then tell your agent: **“Review my code.”**
 
 ## Installation
 
-### CodeRabbit CLI
+### 1. Install the CodeRabbit CLI
 
 Use the [CLI docs](https://docs.coderabbit.ai/cli) for the primary install path.
 They cover Homebrew, the install script, authentication, and CLI usage.
 
-### Other install paths from this repo
+### 2. Install the agent integration
+
+Choose the path that matches your coding agent.
 
 #### Skills installer
 
-For manual skills installation, use the
-[skills docs](https://docs.coderabbit.ai/cli/skills):
+For agents that support portable `SKILL.md` files, use the
+[skills docs](https://docs.coderabbit.ai/cli/skills).
 
 ```bash
 npx skills add coderabbitai/skills
@@ -44,31 +50,9 @@ Installation options for the skills installer:
 | `-s, --skill`  | Install particular skills by name                |
 | `--all`        | Install all skills to all agents without prompts |
 
-#### Tagged release archives for binary installers
-
-Consumers embedding these skills in a binary or installer should pin an
-immutable release tag and verify the downloaded archive before unpacking it.
-Do not consume branch archives such as `refs/heads/main`.
-
-Every `v*` release tag publishes these GitHub release assets:
-
-- `coderabbit-skills-vX.Y.Z.tar.gz`
-- `coderabbit-skills-vX.Y.Z.sha256`
-- `release-manifest.json`
-
-Preferred install flow for non-interactive consumers:
-
-1. Pin a release tag such as `v1.1.1`.
-2. Download `release-manifest.json` and `coderabbit-skills-vX.Y.Z.tar.gz` from
-   that release.
-3. Verify the archive SHA-256 against the manifest or `.sha256` asset.
-4. Reject the install if the checksum does not match.
-
-### Claude Code Plugin
+#### Claude Code Plugin
 
 Claude Code users can also install this as a plugin directly from the official marketplace:
-
-In Claude Code:
 
 ```text
 /plugin marketplace update
@@ -99,6 +83,18 @@ Codex users can install the official CodeRabbit plugin by following the
 
 For an at-a-glance inventory of active and repo-packaged distribution paths, see
 [DISTRIBUTION_CHANNELS.md](DISTRIBUTION_CHANNELS.md).
+
+## What Lives Here
+
+| Path | Purpose |
+| --- | --- |
+| `skills/` | Portable CodeRabbit skills for agents that support `SKILL.md`. |
+| `.claude-plugin/` | Claude Code plugin marketplace metadata. |
+| `commands/` | Claude Code slash commands shipped by the plugin. |
+| `agents/` | Claude Code subagents shipped by the plugin. |
+| `.cursor-plugin/` | Cursor marketplace metadata. |
+| `assets/` | Shared marketplace and brand assets. |
+| `DISTRIBUTION_CHANNELS.md` | Maintainer inventory of live, packaged, and in-development channels. |
 
 ## Usage
 
@@ -205,6 +201,22 @@ Safe fix workflow for unresolved CodeRabbit GitHub PR review threads, with per-i
 - Parses and prioritizes issues by severity
 - Applies fixes only after validating the issue and getting approval
 - Produces a single consolidated commit and posts a PR summary comment
+
+## Plugin Components
+
+### Claude Code
+
+- Slash command: `/coderabbit:review`
+- Subagent: `code-reviewer`
+- Marketplace manifest: `.claude-plugin/plugin.json`
+
+The `code-review` skill also remains available for natural-language triggering
+inside compatible agents.
+
+### Cursor
+
+- Marketplace manifest: `.cursor-plugin/plugin.json`
+- Skills source: `skills/`
 
 ## Resources
 

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,4 +1,5 @@
 ---
+name: code-reviewer
 description: Specialized CodeRabbit code review agent that performs thorough analysis of code changes
 capabilities:
   - Run comprehensive code reviews using CodeRabbit AI

--- a/commands/coderabbit-review.md
+++ b/commands/coderabbit-review.md
@@ -1,7 +1,7 @@
 ---
 description: Run CodeRabbit AI code review on your changes
-argument-hint: [type] [--base <branch>]
-allowed-tools: Bash(coderabbit:*), Bash(cr:*), Bash(git:*)
+argument-hint: "[type] [--base <branch>]"
+allowed-tools: "Bash(coderabbit:*), Bash(cr:*), Bash(git:*)"
 ---
 
 # CodeRabbit Code Review


### PR DESCRIPTION
## Summary
- Reframe README as the canonical home for CodeRabbit skills and plugin packaging
- Keep tagged release archive guidance maintainer-only while it remains in development
- Add subagent/frontmatter cleanup and local repo ignores

## Validation
- ruby frontmatter parser check
- plugin JSON parse check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated README to clarify CodeRabbit agent-native skills and plugin packaging as primary focus
  * Reorganized installation instructions into numbered steps for clearer guidance
  * Added "What Lives Here" section documenting repository structure
  * Updated plugin component documentation with marketplace and command details
  * Updated distribution channel documentation

* **Chores**
  * Expanded `.gitignore` to exclude additional development artifacts
  * Updated YAML formatting in documentation files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->