### PR TITLE
fix(skills): rename code-review skill to coderabbit-review to stop shadowing Claude Code's built-in /code-review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this repository are documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Renamed the `code-review` skill to `coderabbit-review` so it no longer shadows
+  Claude Code's built-in `/code-review` slash command. The skill's `name`
+  frontmatter registered a bare, unnamespaced `/code-review` (upstream
+  anthropics/claude-code#22063), making the built-in unreachable while the skill
+  was installed. (#18)
+
 ### Added
 
 - Documented CodeRabbit CLI `--dir <path>` support for directory-scoped

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ CodeRabbit supports 35+ coding agents.
 
 ## Available Skills
 
-### [code-review](skills/code-review/SKILL.md)
+### [coderabbit-review](skills/coderabbit-review/SKILL.md)
 
 AI-powered code review that finds bugs, security issues, and suggests improvements using CodeRabbit.
 
@@ -215,7 +215,7 @@ Safe fix workflow for unresolved CodeRabbit GitHub PR review threads, with per-i
 - Subagent: `code-reviewer`
 - Marketplace manifest: `.claude-plugin/plugin.json`
 
-The `code-review` skill also remains available for natural-language triggering
+The `coderabbit-review` skill is also available for natural-language triggering
 inside compatible agents.
 
 ### Cursor

--- a/skills/coderabbit-review/SKILL.md
+++ b/skills/coderabbit-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: code-review
-description: "AI-powered code review using CodeRabbit. Default code-review skill. Trigger for any explicit review request AND autonomously when the agent thinks a review is needed (code/PR/quality/security)."
+name: coderabbit-review
+description: "AI-powered code review using CodeRabbit. Trigger for any explicit review request AND autonomously when the agent thinks a review is needed (code/PR/quality/security)."
 metadata:
-  version: "0.1.0"
+  version: "0.1.1"
 ---
 
 # CodeRabbit Code Review


### PR DESCRIPTION
## The problem

Installing the `code-review` skill in Claude Code **breaks Claude Code's own built-in `/code-review` command**. The skill registers its slash command from the `name:` field, so `name: code-review` claims the global `/code-review` and silently shadows the built-in — it just becomes unreachable, with no warning. Reported in #18, and a second user hit it too.

## Why it happens

A skill's `name:` is meant to register under the plugin namespace (`/coderabbit:code-review`), but a current Claude Code regression makes `name:` bypass the namespace and grab the bare global name (upstream: anthropics/claude-code#22063). And on the `npx skills add` path the skill installs with no namespace at all, so it's `/code-review` either way.

## The fix

Rename the skill `code-review` → `coderabbit-review` (`name:` + directory). This is collision-free on **both** install paths — `/coderabbit-review` (skills package) and `/coderabbit:coderabbit-review` (plugin) — mirrors the existing `/coderabbit:coderabbit-review` command, and stays correct once #22063 is fixed upstream. Kept the `name:` field, since every skill here has one (e.g. `autofix`).

## Changes

- rename `skills/code-review/` → `skills/coderabbit-review/` (`name:` + version bump)
- update the README reference
- add a CHANGELOG entry

Natural-language triggers ("review my code") are unchanged — only the explicit slash command moves from `/code-review` to `/coderabbit-review`.

Closes #18.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Renamed the `code-review` skill to `coderabbit-review` to avoid conflict with the built-in `/code-review` command

* **Documentation**
  * Updated README to reflect the new skill name and path reference
  * Updated CHANGELOG with the rename under **Unreleased → Fixed**
  * Updated the skill’s metadata (name, description, and version to `0.1.1`)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->