### PR TITLE
Add native Antigravity CLI plugin packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this repository are documented in this file.
 
 ### Added
 
+- Added native Antigravity CLI plugin packaging via the repository-root
+  `plugin.json` manifest, with direct GitHub installation guidance.
 - Documented CodeRabbit CLI `--dir <path>` support for directory-scoped
   reviews in the review skill and Claude Code review helpers.
 - Added `name` frontmatter to the Claude Code `code-reviewer` subagent.

--- a/DISTRIBUTION_CHANNELS.md
+++ b/DISTRIBUTION_CHANNELS.md
@@ -1,6 +1,6 @@
 # Distribution Channels
 
-Last verified: 2026-04-28
+Last verified: 2026-07-20
 
 This file is the repository's operating inventory for where CodeRabbit skills and adjacent agent integrations are distributed. Public user-facing install guidance belongs in `README.md`; in-development and maintainer-only channels should stay here until they are ready to launch.
 
@@ -12,6 +12,7 @@ This file is the repository's operating inventory for where CodeRabbit skills an
 | Tagged GitHub release archive for binary installers | In development, not user-facing | `.github/workflows/release.yml` | Workflow publishes a versioned tarball, SHA-256 file, and release manifest on `v*` tags, but this channel is not part of public install guidance yet. |
 | Claude Code plugin marketplace | Live, source migration pending | `.claude-plugin/plugin.json`, `commands/`, `agents/` | In-repo packaging is active; official marketplace source is being moved from `coderabbitai/claude-plugin` to this repository. |
 | Cursor native plugin marketplace | Repo-packaged, publication should be verified | `.cursor-plugin/plugin.json` | Repo contains marketplace manifest; treat public listing as separate verification work. |
+| Antigravity CLI native plugin | GitHub-installable | `plugin.json`, `skills/` | Install directly with `agy plugin install https://github.com/coderabbitai/skills`; treat marketplace publication as separate verification work. |
 | Codex plugin marketplace | Live, separate repo | CodeRabbit docs + `coderabbitai/codex-plugin` | Not packaged from this repository today. |
 | VS Code / Cursor / Windsurf IDE extension | Live, separate distribution | CodeRabbit IDE extension docs | Complements skills; not a replacement for `SKILL.md` installs. |
 | GitHub Marketplace app (PR reviews) | Live, separate product channel | CodeRabbit GitHub Marketplace listing | Product distribution, not a skills install path. |
@@ -21,5 +22,6 @@ This file is the repository's operating inventory for where CodeRabbit skills an
 - When README install text changes, verify this table still matches the recommended paths.
 - When the release workflow or asset names change, update the binary-installer row and its verification note.
 - When a new marketplace manifest is added, record whether it is only packaged in-repo or publicly published.
+- When the Antigravity manifest or plugin schema changes, rerun `agy plugin validate .`.
 - If a channel moves to another repository, keep the status here and link the new owner repo in the note.
 - If a channel is deprecated, keep it in this file until all docs and install references are removed.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Agents](https://img.shields.io/badge/works_with-35%2B_agents-brightgreen)](#supported-agents)
 
 The canonical home for CodeRabbit's agent-native skills and plugin packaging.
-Use it to install AI-powered code review into 35+ coding agents, Claude Code,
-Cursor, and other supported agent environments.
+Use it to install AI-powered code review into 35+ coding agents, Antigravity
+CLI, Claude Code, Cursor, and other supported agent environments.
 
 CodeRabbit detects bugs, security issues, and quality risks before you merge.
 
@@ -76,6 +76,19 @@ After publication, Cursor marketplace installs use:
 For the current recommended setup, see the
 [Cursor integration guide](https://docs.coderabbit.ai/cli/cursor-integration).
 
+#### Antigravity CLI Plugin
+
+Antigravity CLI users can install the native plugin directly from this
+repository:
+
+```bash
+agy plugin install https://github.com/coderabbitai/skills
+agy plugin list
+```
+
+The repository-root [`plugin.json`](plugin.json) manifest packages the skills,
+review command, and code-review subagent for Antigravity CLI's plugin discovery.
+
 #### Codex App
 
 Codex users can install the official CodeRabbit plugin by following the
@@ -90,9 +103,10 @@ For an at-a-glance inventory of active and repo-packaged distribution paths, see
 | --- | --- |
 | `skills/` | Portable CodeRabbit skills for agents that support `SKILL.md`. |
 | `.claude-plugin/` | Claude Code plugin marketplace metadata. |
-| `commands/` | Claude Code slash commands shipped by the plugin. |
-| `agents/` | Claude Code subagents shipped by the plugin. |
+| `commands/` | Review command shipped to Claude Code and converted to a skill by Antigravity CLI. |
+| `agents/` | Code-review subagent shipped to Claude Code and Antigravity CLI. |
 | `.cursor-plugin/` | Cursor marketplace metadata. |
+| `plugin.json` | Antigravity CLI plugin manifest. |
 | `assets/` | Shared marketplace and brand assets. |
 | `DISTRIBUTION_CHANNELS.md` | Maintainer inventory of live, packaged, and in-development channels. |
 
@@ -126,7 +140,7 @@ CodeRabbit supports 35+ coding agents.
 | Agent              | Project Path           | Global Path                            |
 | ------------------ | ---------------------- | -------------------------------------- |
 | Amp, Kimi Code CLI | `.agents/skills/`      | `~/.config/agents/skills/`             |
-| Antigravity        | `.agent/skills/`       | `~/.gemini/antigravity/global_skills/` |
+| Antigravity CLI    | `.agents/skills/`      | `~/.gemini/config/skills/`              |
 | Claude Code        | `.claude/skills/`      | `~/.claude/skills/`                    |
 | Cline              | `.cline/skills/`       | `~/.cline/skills/`                     |
 | CodeBuddy          | `.codebuddy/skills/`   | `~/.codebuddy/skills/`                 |
@@ -223,12 +237,20 @@ inside compatible agents.
 - Marketplace manifest: `.cursor-plugin/plugin.json`
 - Skills source: `skills/`
 
+### Antigravity CLI
+
+- Native plugin manifest: `plugin.json`
+- Skills source: `skills/`
+- Review command: `commands/coderabbit-review.md` (converted to a skill during installation)
+- Subagent: `agents/code-reviewer.md`
+
 ## Resources
 
 - [CodeRabbit Documentation](https://coderabbit.ai/docs)
 - [CodeRabbit CLI Guide](https://docs.coderabbit.ai/cli)
 - [Vercel Skills CLI](https://github.com/vercel-labs/skills)
 - [Agent Skills Specification](https://agentskills.io/specification)
+- [Antigravity CLI Plugin Documentation](https://antigravity.google/docs/cli-plugins)
 
 ## License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "coderabbit",
+  "description": "AI-powered code review and review-comment autofix, powered by CodeRabbit."
+}


### PR DESCRIPTION
## What changed

- Add the repository-root `plugin.json` manifest required by Antigravity CLI.
- Document direct installation with `agy plugin install https://github.com/coderabbitai/skills` and verification with `agy plugin list`.
- Correct Antigravity's workspace and global skill paths, and record the native distribution channel in the changelog and maintainer inventory.

## Before → After

Before: the repository was available through generic skill installers but had no native Antigravity plugin manifest, and its Antigravity paths were stale.

After: Antigravity CLI can install the repository as a native plugin and discover its two skills, code-review subagent, and review command.

## Validation

- Antigravity CLI 1.1.4: `agy plugin validate .`
  - 2 skills processed
  - 1 agent processed
  - 1 command processed and converted to a skill
- `git diff --check`

## Related

- [DX-937](https://linear.app/coderabbit/issue/DX-937/add-antigravity-cli-support-after-gemini-cli-deprecation)
- Runtime detection: [coderabbitai/mono#19563](https://github.com/coderabbitai/mono/pull/19563)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Antigravity CLI plugin packaging and GitHub installation support.
  * Added setup guidance for installing, listing, and using the plugin through the Antigravity CLI.
  * Documented the plugin’s included skills, review command, and code-review subagent.

* **Documentation**
  * Updated supported installation paths, plugin components, resources, and distribution-channel records.
  * Added maintenance guidance for validating the plugin manifest when packaging requirements change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->