### PR TITLE
feat: add native Gemini CLI extension packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this repository are documented in this file.
 
 ### Added
 
+- Added native Gemini CLI extension packaging via `gemini-extension.json`,
+  including the `/coderabbit:review` command and existing portable skills.
 - Added native Antigravity CLI plugin packaging via the repository-root
   `plugin.json` manifest, with direct GitHub installation guidance.
 - Documented CodeRabbit CLI `--dir <path>` support for directory-scoped
@@ -16,6 +18,7 @@ All notable changes to this repository are documented in this file.
 
 ### Changed
 
+- Aligned the shared code-review subagent metadata with Gemini CLI's schema.
 - Removed alternate detailed-output guidance so review agents use `--agent`
   exclusively.
 - Reframed the README as the canonical home for CodeRabbit skills and plugin

--- a/DISTRIBUTION_CHANNELS.md
+++ b/DISTRIBUTION_CHANNELS.md
@@ -1,6 +1,6 @@
 # Distribution Channels
 
-Last verified: 2026-07-20
+Last verified: 2026-08-04
 
 This file is the repository's operating inventory for where CodeRabbit skills and adjacent agent integrations are distributed. Public user-facing install guidance belongs in `README.md`; in-development and maintainer-only channels should stay here until they are ready to launch.
 
@@ -12,6 +12,7 @@ This file is the repository's operating inventory for where CodeRabbit skills an
 | Tagged GitHub release archive for binary installers | In development, not user-facing | `.github/workflows/release.yml` | Workflow publishes a versioned tarball, SHA-256 file, and release manifest on `v*` tags, but this channel is not part of public install guidance yet. |
 | Claude Code plugin marketplace | Live, source migration pending | `.claude-plugin/plugin.json`, `commands/`, `agents/` | In-repo packaging is active; official marketplace source is being moved from `coderabbitai/claude-plugin` to this repository. |
 | Cursor native plugin marketplace | Repo-packaged, publication should be verified | `.cursor-plugin/plugin.json` | Repo contains marketplace manifest; treat public listing as separate verification work. |
+| Gemini CLI native extension | Repo-packaged, release pending | `gemini-extension.json`, `skills/`, `commands/coderabbit/review.toml`, `agents/` | Publish direct installation after `v1.2.0`; verify gallery listing separately. |
 | Antigravity CLI native plugin | GitHub-installable | `plugin.json`, `skills/` | Install directly with `agy plugin install https://github.com/coderabbitai/skills`; treat marketplace publication as separate verification work. |
 | Codex plugin marketplace | Live, separate repo | CodeRabbit docs + `coderabbitai/codex-plugin` | Not packaged from this repository today. |
 | VS Code / Cursor / Windsurf IDE extension | Live, separate distribution | CodeRabbit IDE extension docs | Complements skills; not a replacement for `SKILL.md` installs. |
@@ -22,6 +23,7 @@ This file is the repository's operating inventory for where CodeRabbit skills an
 - When README install text changes, verify this table still matches the recommended paths.
 - When the release workflow or asset names change, update the binary-installer row and its verification note.
 - When a new marketplace manifest is added, record whether it is only packaged in-repo or publicly published.
+- When the Gemini manifest or bundled components change, rerun `gemini extensions validate .`.
 - When the Antigravity manifest or plugin schema changes, rerun `agy plugin validate .`.
 - If a channel moves to another repository, keep the status here and link the new owner repo in the note.
 - If a channel is deprecated, keep it in this file until all docs and install references are removed.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Agents](https://img.shields.io/badge/works_with-35%2B_agents-brightgreen)](#supported-agents)
 
 The canonical home for CodeRabbit's agent-native skills and plugin packaging.
-Use it to install AI-powered code review into 35+ coding agents, Antigravity
-CLI, Claude Code, Cursor, and other supported agent environments.
+Use it to install AI-powered code review into 35+ coding agents, Gemini CLI,
+Antigravity CLI, Claude Code, Cursor, and other supported agent environments.
 
 CodeRabbit detects bugs, security issues, and quality risks before you merge.
 
@@ -76,6 +76,19 @@ After publication, Cursor marketplace installs use:
 For the current recommended setup, see the
 [Cursor integration guide](https://docs.coderabbit.ai/cli/cursor-integration).
 
+#### Gemini CLI Extension
+
+Gemini CLI users can install the native extension directly from this repository:
+
+```bash
+gemini extensions install https://github.com/coderabbitai/skills
+gemini extensions list
+```
+
+The repository-root [`gemini-extension.json`](gemini-extension.json) packages
+the portable skills, `/coderabbit:review` command, and code-review subagent.
+This native extension is separate from the generic skills-installer path above.
+
 #### Antigravity CLI Plugin
 
 Antigravity CLI users can install the native plugin directly from this
@@ -103,9 +116,10 @@ For an at-a-glance inventory of active and repo-packaged distribution paths, see
 | --- | --- |
 | `skills/` | Portable CodeRabbit skills for agents that support `SKILL.md`. |
 | `.claude-plugin/` | Claude Code plugin marketplace metadata. |
-| `commands/` | Review command shipped to Claude Code and converted to a skill by Antigravity CLI. |
-| `agents/` | Code-review subagent shipped to Claude Code and Antigravity CLI. |
+| `commands/` | Native review commands for Claude Code, Gemini CLI, and Antigravity CLI. |
+| `agents/` | Code-review subagent shipped to Claude Code, Gemini CLI, and Antigravity CLI. |
 | `.cursor-plugin/` | Cursor marketplace metadata. |
+| `gemini-extension.json` | Gemini CLI extension manifest. |
 | `plugin.json` | Antigravity CLI plugin manifest. |
 | `assets/` | Shared marketplace and brand assets. |
 | `DISTRIBUTION_CHANNELS.md` | Maintainer inventory of live, packaged, and in-development channels. |
@@ -244,12 +258,20 @@ inside compatible agents.
 - Review command: `commands/coderabbit-review.md` (converted to a skill during installation)
 - Subagent: `agents/code-reviewer.md`
 
+### Gemini CLI
+
+- Native extension manifest: `gemini-extension.json`
+- Skills source: `skills/`
+- Slash command: `/coderabbit:review` (`commands/coderabbit/review.toml`)
+- Subagent: `agents/code-reviewer.md`
+
 ## Resources
 
 - [CodeRabbit Documentation](https://coderabbit.ai/docs)
 - [CodeRabbit CLI Guide](https://docs.coderabbit.ai/cli)
 - [Vercel Skills CLI](https://github.com/vercel-labs/skills)
 - [Agent Skills Specification](https://agentskills.io/specification)
+- [Gemini CLI Extension Documentation](https://geminicli.com/docs/extensions/reference/)
 - [Antigravity CLI Plugin Documentation](https://antigravity.google/docs/cli-plugins)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -76,14 +76,17 @@ After publication, Cursor marketplace installs use:
 For the current recommended setup, see the
 [Cursor integration guide](https://docs.coderabbit.ai/cli/cursor-integration).
 
-#### Gemini CLI Extension
+#### Gemini CLI Extension (pre-release)
 
-Gemini CLI users can install the native extension directly from this repository:
+Until `v1.2.0` is published as the Latest release, Gemini CLI users can install
+the native extension from `main`:
 
 ```bash
-gemini extensions install https://github.com/coderabbitai/skills
+gemini extensions install https://github.com/coderabbitai/skills --ref main
 gemini extensions list
 ```
+
+After `v1.2.0` is published, the `--ref main` option can be omitted.
 
 The repository-root [`gemini-extension.json`](gemini-extension.json) packages
 the portable skills, `/coderabbit:review` command, and code-review subagent.

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,13 +1,6 @@
 ---
 name: code-reviewer
 description: Specialized CodeRabbit code review agent that performs thorough analysis of code changes
-capabilities:
-  - Run comprehensive code reviews using CodeRabbit AI
-  - Review a requested repository directory with CodeRabbit CLI --dir
-  - Identify security vulnerabilities and best practice violations
-  - Provide actionable fix suggestions with code examples
-  - Analyze code complexity and maintainability
-  - Review for performance optimizations
 ---
 
 # CodeRabbit Code Review Agent

--- a/commands/coderabbit/review.toml
+++ b/commands/coderabbit/review.toml
@@ -1,0 +1,5 @@
+description = "Run CodeRabbit AI code review on your changes"
+prompt = """
+Activate the `code-review` skill and follow its workflow to review the current changes.
+Apply this requested scope or additional instruction when provided: {{args}}
+"""

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,5 @@
+{
+  "name": "coderabbit",
+  "version": "1.2.0",
+  "description": "AI-powered code review and review-comment autofix, powered by CodeRabbit."
+}


### PR DESCRIPTION
## What changed

- Add a root `gemini-extension.json` manifest for native Gemini CLI installation.
- Add a thin Gemini TOML adapter for the branded `/coderabbit:review` command.
- Remove unsupported `capabilities` frontmatter so the shared `code-reviewer` agent loads under Gemini's strict schema.
- Document the new package and its release state in the README, distribution inventory, and changelog.

## Before → After

**Before:** CodeRabbit's portable Agent Skill could be installed for Gemini CLI, but `gemini extensions install https://github.com/coderabbitai/skills` failed because the repository had no Gemini manifest. Gemini also ignored the Claude Markdown command and rejected the shared subagent metadata.

**After:** The repository validates as a native Gemini CLI extension and exposes the existing skills, a branded `/coderabbit:review` command, and the shared `code-reviewer` subagent. No separate Gemini repository, MCP server, hook, or backend path is introduced.

## Compatibility

- Keep the shared `code-review` skill name unchanged; `/coderabbit:review` avoids Google's existing `/code-review` command surface.
- The removed agent frontmatter duplicated content already present in the Markdown body.
- Existing Antigravity packaging still validates successfully.
- Gemini Code Assist IDE and its GitHub App remain separate products and are not claimed as supported by this package.

## Validation

- `gemini extensions validate .` — pass with Gemini CLI 0.40.0
- `agy plugin validate .` — pass: 2 skills, 1 agent, 2 converted commands
- JSON and TOML parse checks — pass
- `git diff --check` — pass

- `gemini extensions install https://github.com/coderabbitai/skills --ref nehal/gemini-cli-extension --consent --skip-settings` — pass
- `gemini extensions list` — pass: showed `coderabbit (1.2.0)` and discovered both bundled skills
- The temporary extension install was removed after validation. Interactive `/coderabbit:review` invocation remains unverified because Gemini authentication was unavailable.

## Release gates

- Reconcile or land #23 before publishing so the bundled review guidance uses the CLI 0.7 public scope flags.
- Publish and mark `v1.2.0` as Latest; the current Latest release, `v1.1.1`, predates this manifest, so the unqualified install command will not work until then.
- Add the `gemini-cli-extension` repository topic after release if gallery discovery is desired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for installing and using the project as a native Gemini CLI extension.
  - Documented the extension’s packaged components, setup steps, and Gemini CLI resources.

- **Documentation**
  - Updated command and subagent guidance to include Gemini CLI.
  - Added distribution, release, and maintenance guidance for validating the extension.
  - Updated supported-environment and repository inventory information to reflect Gemini CLI availability.
  - Aligned code-review configuration documentation with Gemini CLI metadata requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
