### PR TITLE
chore: add repository CodeRabbit policy

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# This public repository owns a complete, versioned review policy rather than
+# inheriting private organization configuration.
+inheritance: false
+
+reviews:
+  profile: assertive
+
+  # Hold CodeRabbit approval until every CodeRabbit comment is resolved,
+  # including nitpicks and comments outside the diff, and pre-merge checks pass.
+  request_changes_workflow: true
+
+  review_status: true
+  in_progress_fortune: true
+  poem: true
+  enable_prompt_for_ai_agents: true
+
+  auto_review:
+    enabled: true
+    drafts: true
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 1
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: true
+
+  path_instructions:
+    - path: "skills/**/SKILL.md"
+      instructions: |
+        Treat skill files as executable agent instructions.
+        Flag ambiguous, conflicting, unsafe, or unavailable commands.
+        Keep guidance portable across declared agents unless it is explicitly scoped.
+        Verify CLI commands and options against current public documentation.
+        Prefer the smallest reliable workflow; avoid redundant preflights and duplicate state machines.
+        Preserve normal user-approval and sandbox boundaries.
+
+    - path: "commands/**/*.md"
+      instructions: |
+        Keep native commands behaviorally aligned with the corresponding canonical skill.
+        Flag stale CLI options, unsafe shell construction, and duplicated prerequisite logic.
+
+    - path: "agents/**/*.md"
+      instructions: |
+        Keep agent workflows behaviorally aligned with the corresponding canonical skill and commands.
+        Flag conflicting prerequisites, review scopes, or remediation guidance.
+
+    - path: "{.claude-plugin,.cursor-plugin}/**/*.json"
+      instructions: |
+        Verify manifest paths, versions, metadata, and packaged components against the repository tree.
+
+    - path: "{gemini-extension.json,plugin.json}"
+      instructions: |
+        Verify manifest paths, metadata, and packaged components against the repository tree.
+
+    - path: "{README.md,CHANGELOG.md,DISTRIBUTION_CHANNELS.md}"
+      instructions: |
+        Keep public installation commands, release status, and source-of-truth claims accurate and mutually consistent.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,7 +20,7 @@ reviews:
     enabled: true
     drafts: true
     auto_incremental_review: true
-    auto_pause_after_reviewed_commits: 0
+    auto_pause_after_reviewed_commits: 1
 
   finishing_touches:
     docstrings:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
-# This public repository owns a complete, versioned review policy rather than
-# inheriting private organization configuration.
+# This public repository owns a complete, versioned review policy.
 inheritance: false
 
 reviews:
@@ -13,16 +12,32 @@ reviews:
 
   pre_merge_checks:
     override_requested_reviewers_only: true
-    docstrings:
-      mode: error
     title:
       mode: error
     description:
       mode: error
     issue_assessment:
       mode: error
+    custom_checks:
+      - name: Agent guidance structure
+        mode: error
+        instructions: |
+          Pass when the pull request does not change skills, agent guidance,
+          native commands, or their manifests. Otherwise require all of these:
+          - SKILL.md files keep activation, routing, domain context, and workflow
+            framing concise.
+          - Detailed material is loaded through focused references when needed,
+            and repeatable deterministic operations use scripts or tools when
+            practical.
+          - Referenced files, scripts, tools, commands, and options exist and
+            agree with the repository and current public documentation.
+          - Changes follow the Agent Skills specification, the AGENTS.md open
+            format, and current public guidance for each declared host agent.
+          - Native commands, agents, and manifests remain behaviorally aligned
+            with their canonical skills.
 
   review_status: true
+  review_details: true
   in_progress_fortune: true
   poem: true
   enable_prompt_for_ai_agents: true
@@ -31,30 +46,38 @@ reviews:
     enabled: true
     drafts: true
     auto_incremental_review: true
-    auto_pause_after_reviewed_commits: 1
+    auto_pause_after_reviewed_commits: 0
 
   finishing_touches:
-    docstrings:
-      enabled: false
     unit_tests:
       enabled: false
     simplify:
       enabled: true
 
+  tools:
+    actionlint:
+      enabled: true
+    zizmor:
+      enabled: true
+    skillspector:
+      enabled: true
+
   path_instructions:
     - path: "skills/**/SKILL.md"
       instructions: |
-        Treat skill files as executable agent instructions.
-        Flag ambiguous, conflicting, unsafe, or unavailable commands.
+        Keep skill Markdown focused on domain context, routing, and workflow framing.
+        Put repeatable deterministic operations in referenced scripts or tools when practical.
+        Use focused references for details that are only needed in some workflows.
+        Flag ambiguous or conflicting guidance.
         Keep guidance portable across declared agents unless it is explicitly scoped.
         Verify CLI commands and options against current public documentation.
-        Prefer the smallest reliable workflow; avoid redundant preflights and duplicate state machines.
-        Preserve normal user-approval and sandbox boundaries.
+        Check the Agent Skills specification, the AGENTS.md open format, and the
+        current public documentation for every declared host agent.
 
     - path: "commands/**/*.md"
       instructions: |
         Keep native commands behaviorally aligned with the corresponding canonical skill.
-        Flag stale CLI options, unsafe shell construction, and duplicated prerequisite logic.
+        Flag stale CLI options and duplicated prerequisite logic.
 
     - path: "agents/**/*.md"
       instructions: |
@@ -72,3 +95,31 @@ reviews:
     - path: "{README.md,CHANGELOG.md,DISTRIBUTION_CHANNELS.md}"
       instructions: |
         Keep public installation commands, release status, and source-of-truth claims accurate and mutually consistent.
+
+chat:
+  allow_non_org_members: false
+  auto_reply: true
+  integrations:
+    jira:
+      usage: disabled
+    linear:
+      usage: disabled
+
+knowledge_base:
+  learnings:
+    scope: local
+  issues:
+    scope: local
+  jira:
+    usage: disabled
+  linear:
+    usage: disabled
+  pull_requests:
+    scope: local
+  mcp:
+    usage: disabled
+  automatic_repository_linking: false
+
+issue_enrichment:
+  auto_enrich:
+    enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,7 +20,7 @@ reviews:
     enabled: true
     drafts: true
     auto_incremental_review: true
-    auto_pause_after_reviewed_commits: 1
+    auto_pause_after_reviewed_commits: 0
 
   finishing_touches:
     docstrings:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,6 +11,17 @@ reviews:
   # including nitpicks and comments outside the diff, and pre-merge checks pass.
   request_changes_workflow: true
 
+  pre_merge_checks:
+    override_requested_reviewers_only: true
+    docstrings:
+      mode: error
+    title:
+      mode: error
+    description:
+      mode: error
+    issue_assessment:
+      mode: error
+
   review_status: true
   in_progress_fortune: true
   poem: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable changes to this repository are documented in this file.
 ### Added
 
 - Added a self-contained, assertive repository-level CodeRabbit policy with
-  draft reviews, a one-reviewed-commit automatic pause, a strict request-changes
-  workflow, blocking built-in pre-merge checks, and focused guidance for skills,
-  native packaging, and public documentation.
+  draft and continuous incremental reviews, a strict request-changes workflow,
+  blocking pre-merge checks, public-repository knowledge boundaries, and focused
+  guidance for skills, native packaging, and public documentation.
 - Added native Gemini CLI extension packaging via `gemini-extension.json`,
   including the `/coderabbit:review` command and existing portable skills.
 - Added native Antigravity CLI plugin packaging via the repository-root
@@ -27,9 +27,10 @@ All notable changes to this repository are documented in this file.
   exclusively.
 - Reframed the README as the canonical home for CodeRabbit skills and plugin
   packaging across supported agents.
-- Reclassified the tagged release archive channel as in development after the
-  v1.1.1 archive was published, removed its public README install flow, and
-  recorded the current status in `DISTRIBUTION_CHANNELS.md`.
+- Removed public README guidance for tagged release archives while that channel
+  remains in development.
+- Marked the tagged release archive channel as in development in
+  `DISTRIBUTION_CHANNELS.md`.
 - Quoted Claude Code command frontmatter values so standard YAML parsers can
   validate them.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ All notable changes to this repository are documented in this file.
 ### Added
 
 - Added a self-contained, assertive repository-level CodeRabbit policy with
-  draft and continuous incremental reviews, a strict request-changes workflow,
-  and focused guidance for skills, native packaging, and public documentation.
+  draft reviews, a one-reviewed-commit automatic pause, a strict request-changes
+  workflow, and focused guidance for skills, native packaging, and public
+  documentation.
 - Added native Gemini CLI extension packaging via `gemini-extension.json`,
   including the `/coderabbit:review` command and existing portable skills.
 - Added native Antigravity CLI plugin packaging via the repository-root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to this repository are documented in this file.
 
 - Added a self-contained, assertive repository-level CodeRabbit policy with
   draft reviews, a one-reviewed-commit automatic pause, a strict request-changes
-  workflow, and focused guidance for skills, native packaging, and public
-  documentation.
+  workflow, blocking built-in pre-merge checks, and focused guidance for skills,
+  native packaging, and public documentation.
 - Added native Gemini CLI extension packaging via `gemini-extension.json`,
   including the `/coderabbit:review` command and existing portable skills.
 - Added native Antigravity CLI plugin packaging via the repository-root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this repository are documented in this file.
 
 ### Added
 
+- Added a self-contained, assertive repository-level CodeRabbit policy with
+  draft reviews, a strict request-changes workflow, and focused guidance for
+  skills, native packaging, and public documentation.
 - Added native Gemini CLI extension packaging via `gemini-extension.json`,
   including the `/coderabbit:review` command and existing portable skills.
 - Added native Antigravity CLI plugin packaging via the repository-root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to this repository are documented in this file.
 ### Added
 
 - Added a self-contained, assertive repository-level CodeRabbit policy with
-  draft reviews, a strict request-changes workflow, and focused guidance for
-  skills, native packaging, and public documentation.
+  draft and continuous incremental reviews, a strict request-changes workflow,
+  and focused guidance for skills, native packaging, and public documentation.
 - Added native Gemini CLI extension packaging via `gemini-extension.json`,
   including the `/coderabbit:review` command and existing portable skills.
 - Added native Antigravity CLI plugin packaging via the repository-root
@@ -26,10 +26,9 @@ All notable changes to this repository are documented in this file.
   exclusively.
 - Reframed the README as the canonical home for CodeRabbit skills and plugin
   packaging across supported agents.
-- Removed public README guidance for tagged release archives while that channel
-  remains in development.
-- Marked the tagged release archive channel as in development in
-  `DISTRIBUTION_CHANNELS.md`.
+- Reclassified the tagged release archive channel as in development after the
+  v1.1.1 archive was published, removed its public README install flow, and
+  recorded the current status in `DISTRIBUTION_CHANNELS.md`.
 - Quoted Claude Code command frontmatter values so standard YAML parsers can
   validate them.
 


### PR DESCRIPTION
## Summary

- add a self-contained `.coderabbit.yaml` for this public repository
- use assertive, continuous reviews for draft and ready pull requests
- hold CodeRabbit approval until all review comments and blocking pre-merge checks are resolved
- restrict CodeRabbit comment interactions to organization members
- keep learnings, issues, and pull-request context local to this repository
- disable Jira, Linear, MCP, and automatic cross-repository knowledge sources
- enable GitHub Issue enrichment and explicit agent-skill, workflow, and Actions security scanners
- enforce concise skill framing, progressive disclosure, deterministic scripts and tools, and cross-agent standards

## Why

Repository review behavior should be public, versioned, and reviewable alongside the agent skills it governs. This policy deliberately disables inheritance and makes its important behavior and public-context boundaries explicit.

`request_changes_workflow: true` is the documented all-comments gate. Requested reviewers alone may override a failing pre-merge check, so a pull-request author cannot waive the checks on their own contribution.

The explicit tools cover the repository's main artifact types:

- SkillSpector checks agent skills and MCP configuration for malicious or risky patterns.
- actionlint validates GitHub Actions workflow syntax, expressions, and common mistakes.
- zizmor finds GitHub Actions security weaknesses such as dangerous triggers, permissions, and mutable dependencies.

## Validation

- `coderabbit config validate .coderabbit.yaml`
- `git diff --check`
- `coderabbit review --agent --uncommitted -c .coderabbit.yaml` — zero issues
