### PR TITLE
ci: harden release provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,10 @@ on:
       - "v*"
 
 permissions:
+  attestations: write
+  artifact-metadata: write
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -14,9 +17,10 @@ jobs:
 
     steps:
       - name: Check out tagged source
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Build archive, checksum, and manifest
         env:
@@ -56,8 +60,16 @@ jobs:
             "  \"sourceTarballUrl\": \"${SOURCE_TARBALL_URL}\"" \
             '}' > release-manifest.json
 
+      - name: Attest release assets
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-path: |
+            coderabbit-skills-*.tar.gz
+            coderabbit-skills-*.sha256
+            release-manifest.json
+
       - name: Publish GitHub release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: |
             coderabbit-skills-*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ permissions:
   contents: write
   id-token: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -69,10 +73,40 @@ jobs:
             release-manifest.json
 
       - name: Publish GitHub release assets
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          files: |
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          assets=(
             coderabbit-skills-*.tar.gz
             coderabbit-skills-*.sha256
             release-manifest.json
-          generate_release_notes: true
+          )
+
+          retry() {
+            local attempt=1
+            until "$@"; do
+              if (( attempt >= 3 )); then
+                return 1
+              fi
+              sleep $((attempt * 5))
+              attempt=$((attempt + 1))
+            done
+          }
+
+          ensure_release() {
+            if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+              return 0
+            fi
+
+            gh release create "$TAG_NAME" \
+              --verify-tag \
+              --generate-notes \
+              --title "$TAG_NAME"
+          }
+
+          gh --version
+          retry ensure_release
+          retry gh release upload "$TAG_NAME" "${assets[@]}" --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this repository are documented in this file.
 
 ### Changed
 
+- Pinned release workflow actions to immutable commits and added signed GitHub
+  build-provenance attestations for published release assets.
 - Aligned the shared code-review subagent metadata with Gemini CLI's schema.
 - Removed alternate detailed-output guidance so review agents use `--agent`
   exclusively.

--- a/DISTRIBUTION_CHANNELS.md
+++ b/DISTRIBUTION_CHANNELS.md
@@ -9,7 +9,7 @@ This file is the repository's operating inventory for where CodeRabbit skills an
 | Channel | Status | Source of truth | Notes |
 | --- | --- | --- | --- |
 | Skills package (`npx skills add coderabbitai/skills`) | Live | `README.md`, `skills/` | Canonical multi-agent distribution path for 35+ skills-compatible agents. |
-| Tagged GitHub release archive for binary installers | In development, not user-facing | `.github/workflows/release.yml` | Workflow publishes a versioned tarball, SHA-256 file, and release manifest on `v*` tags, but this channel is not part of public install guidance yet. |
+| Tagged GitHub release archive for binary installers | In development, not user-facing | `.github/workflows/release.yml` | Workflow publishes a versioned tarball, SHA-256 file, release manifest, and GitHub build-provenance attestation on protected `v*` tags, but this channel is not part of public install guidance yet. |
 | Claude Code plugin marketplace | Live, source migration pending | `.claude-plugin/plugin.json`, `commands/`, `agents/` | In-repo packaging is active; official marketplace source is being moved from `coderabbitai/claude-plugin` to this repository. |
 | Cursor native plugin marketplace | Repo-packaged, publication should be verified | `.cursor-plugin/plugin.json` | Repo contains marketplace manifest; treat public listing as separate verification work. |
 | Gemini CLI native extension | Repo-packaged, release pending | `gemini-extension.json`, `skills/`, `commands/coderabbit/review.toml`, `agents/` | Publish direct installation after `v1.2.0`; verify gallery listing separately. |
@@ -22,6 +22,8 @@ This file is the repository's operating inventory for where CodeRabbit skills an
 
 - When README install text changes, verify this table still matches the recommended paths.
 - When the release workflow or asset names change, update the binary-installer row and its verification note.
+- Verify published release assets with
+  `gh attestation verify <asset> --repo coderabbitai/skills --signer-workflow coderabbitai/skills/.github/workflows/release.yml --source-ref refs/tags/<tag>`.
 - When a new marketplace manifest is added, record whether it is only packaged in-repo or publicly published.
 - When the Gemini manifest or bundled components change, rerun `gemini extensions validate .`.
 - When the Antigravity manifest or plugin schema changes, rerun `agy plugin validate .`.

--- a/DISTRIBUTION_CHANNELS.md
+++ b/DISTRIBUTION_CHANNELS.md
@@ -9,7 +9,7 @@ This file is the repository's operating inventory for where CodeRabbit skills an
 | Channel | Status | Source of truth | Notes |
 | --- | --- | --- | --- |
 | Skills package (`npx skills add coderabbitai/skills`) | Live | `README.md`, `skills/` | Canonical multi-agent distribution path for 35+ skills-compatible agents. |
-| Tagged GitHub release archive for binary installers | In development, not user-facing | `.github/workflows/release.yml` | Workflow publishes a versioned tarball, SHA-256 file, release manifest, and GitHub build-provenance attestation on protected `v*` tags, but this channel is not part of public install guidance yet. |
+| Tagged GitHub release archive for binary installers | In development, not user-facing | `.github/workflows/release.yml` | Workflow publishes a versioned tarball, SHA-256 file, release manifest, and GitHub build-provenance attestation on `v*` tags. Repository tag protection is required before this channel becomes user-facing. |
 | Claude Code plugin marketplace | Live, source migration pending | `.claude-plugin/plugin.json`, `commands/`, `agents/` | In-repo packaging is active; official marketplace source is being moved from `coderabbitai/claude-plugin` to this repository. |
 | Cursor native plugin marketplace | Repo-packaged, publication should be verified | `.cursor-plugin/plugin.json` | Repo contains marketplace manifest; treat public listing as separate verification work. |
 | Gemini CLI native extension | Repo-packaged, release pending | `gemini-extension.json`, `skills/`, `commands/coderabbit/review.toml`, `agents/` | Publish direct installation after `v1.2.0`; verify gallery listing separately. |


### PR DESCRIPTION
## Summary

- pin the remaining third-party release Actions to immutable commit SHAs
- generate GitHub build-provenance attestations for the release archive, checksum, and manifest
- publish through the runner's GitHub CLI with per-tag serialization, retries,
  idempotent release creation, and clobber-on-rerun asset uploads
- document how consumers can verify published assets

## Why

This repository distributes installable agent guidance from version tags. Immutable Action references reduce dependency-substitution risk, while GitHub attestations let consumers verify that release assets were produced by this repository's tagged workflow.

## Validation

- `git diff --check`
- parsed `.github/workflows/release.yml` successfully with Ruby YAML
- verified each pinned tag-to-commit mapping against its upstream GitHub repository
- verified the `actions/attest` permission and `subject-path` contract against its upstream documentation
- parsed every workflow `run` block successfully with `bash -n`
- verified `gh release create --verify-tag --generate-notes` and
  `gh release upload --clobber` against the current GitHub CLI documentation
- addressed hosted review feedback by removing the superfluous release action,
  serializing publication by `github.ref`, and using idempotent CLI publication

## Repository setting

Complete: active ruleset `Protect version tags` targets `refs/tags/v*` and restricts creation, update, deletion, and non-fast-forward changes to repository administrators.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Improvements**
  - Release assets now include signed build-provenance attestations for improved authenticity and supply-chain verification.
  - Published release assets can be verified using SHA-256 checksums and GitHub’s attestation tools.
  - Release publishing is more reliable, including automatic release creation and safe replacement of existing assets.

- **Documentation**
  - Updated the changelog and distribution guidance with verification instructions and release security details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->