### PR TITLE
feat: add cloud session handoff skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "coderabbit",
-  "version": "1.1.1",
-  "description": "AI-powered code review in Claude Code, powered by CodeRabbit",
+  "version": "1.2.0",
+  "description": "AI-powered code review, autofix, and cloud coding-session handoff in Claude Code, powered by CodeRabbit",
   "homepage": "https://docs.coderabbit.ai/cli/claude-code-integration",
   "author": {
     "name": "CodeRabbit AI",
@@ -14,6 +14,7 @@
     "code-review",
     "ai",
     "coderabbit",
-    "claude-code"
+    "claude-code",
+    "session-handoff"
   ]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "coderabbit",
   "displayName": "CodeRabbit",
-  "version": "1.1.1",
-  "description": "AI-powered code review and review-comment autofix for Cursor, powered by CodeRabbit.",
+  "version": "1.2.0",
+  "description": "AI-powered code review, review-comment autofix, and cloud coding-session handoff for Cursor, powered by CodeRabbit.",
   "author": {
     "name": "CodeRabbit AI",
     "email": "support@coderabbit.ai"
@@ -17,14 +17,16 @@
     "code-review",
     "security",
     "github",
-    "cursor"
+    "cursor",
+    "session-handoff"
   ],
   "category": "developer-tools",
   "tags": [
     "code-review",
     "security",
     "github",
-    "developer-tools"
+    "developer-tools",
+    "session-handoff"
   ],
   "skills": "./skills/"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this repository are documented in this file.
 
 ### Added
 
+- Added `import-cloud-session` and `export-cloud-session` portable skills for
+  moving committed coding work between local agents and CodeRabbit Cloud using
+  Git plus encrypted summary and optional Plan artifacts.
 - Added native Gemini CLI extension packaging via `gemini-extension.json`,
   including the `/coderabbit:review` command and existing portable skills.
 - Added native Antigravity CLI plugin packaging via the repository-root

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 [![Agents](https://img.shields.io/badge/works_with-35%2B_agents-brightgreen)](#supported-agents)
 
 The canonical home for CodeRabbit's agent-native skills and plugin packaging.
-Use it to install AI-powered code review into 35+ coding agents, Gemini CLI,
-Antigravity CLI, Claude Code, Cursor, and other supported agent environments.
+Use it to install AI-powered code review and cloud coding-session handoff into
+35+ coding agents, Gemini CLI, Antigravity CLI, Claude Code, Cursor, and other
+supported agent environments.
 
 CodeRabbit detects bugs, security issues, and quality risks before you merge.
 
@@ -138,9 +139,11 @@ What's wrong with my changes?
 Run a code review
 Review my PR
 Review the directory at ../my-service
+Continue CodeRabbit cloud task <task-id> locally
+Continue this local coding session in CodeRabbit Cloud
 ```
 
-The agent will automatically:
+For code review, the agent will automatically:
 
 1. Check if CodeRabbit CLI is installed and authenticated
 2. Run the review on your changes
@@ -149,6 +152,10 @@ The agent will automatically:
 
 When you ask for a specific review directory, the agent can pass CodeRabbit CLI
 `--dir <path>` after confirming that path is an initialized Git repository.
+
+For a cloud session handoff, the agent validates the repository and Git state,
+moves code through the configured Git remote, and uses the CodeRabbit CLI to
+transfer an encrypted summary and optional primary Plan.
 
 ## Supported Agents
 
@@ -237,6 +244,38 @@ Safe fix workflow for unresolved CodeRabbit GitHub PR review threads, with per-i
 - Parses and prioritizes issues by severity
 - Applies fixes only after validating the issue and getting approval
 - Produces a single consolidated commit and posts a PR summary comment
+
+### [import-cloud-session](skills/import-cloud-session/SKILL.md)
+
+Continue a background CodeRabbit cloud coding task in a local coding agent.
+
+**Use when:**
+
+- You have a CodeRabbit cloud task ID and want to continue it locally
+- You want the agent to synchronize the task branch before using its summary
+- You need explicit keep-local or keep-remote handling for divergent history
+
+**Capabilities:**
+
+- Enforces repository, branch, origin, clean-worktree, and exact-commit checks
+- Fast-forwards the verified task branch without automatic merge or rebase
+- Imports an encrypted summary and optional primary Plan through the CodeRabbit CLI
+
+### [export-cloud-session](skills/export-cloud-session/SKILL.md)
+
+Continue a local coding-agent session in CodeRabbit Cloud.
+
+**Use when:**
+
+- You want to continue committed local work in an existing cloud task
+- You want to create a new cloud task without supplying a task ID
+- You need explicit keep-local or keep-remote handling for divergent history
+
+**Capabilities:**
+
+- Verifies that committed code is present at the exact remote Git commit
+- Exports an encrypted summary and optional primary Plan through the CodeRabbit CLI
+- Continues an existing cloud task or creates an idempotent branch-backed task
 
 ## Plugin Components
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "coderabbit",
   "version": "1.2.0",
-  "description": "AI-powered code review and review-comment autofix, powered by CodeRabbit."
+  "description": "AI-powered code review, review-comment autofix, and cloud coding-session handoff, powered by CodeRabbit."
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,4 +1,4 @@
 {
   "name": "coderabbit",
-  "description": "AI-powered code review and review-comment autofix, powered by CodeRabbit."
+  "description": "AI-powered code review, review-comment autofix, and cloud coding-session handoff, powered by CodeRabbit."
 }

--- a/skills/export-cloud-session/SKILL.md
+++ b/skills/export-cloud-session/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: export-cloud-session
+description: Export the current Codex, Claude, or other local coding-agent session to CodeRabbit Cloud. Use when continuing committed local work in an existing background task, creating a new cloud task when no taskId is supplied, or resolving a local-to-cloud Git conflict.
+---
+
+# Export Cloud Session
+
+Own every Git operation for a local-to-cloud handoff. Use the CodeRabbit CLI
+only to authenticate and transfer the encrypted `SUMMARY.md` and optional
+primary `PLAN.md`; it does not fetch, switch, merge, reset, commit, or push.
+
+## Local source
+
+1. Run all commands from the repository being handed off. Accept an existing
+   `taskId` when supplied; otherwise create a new cloud task from the current
+   branch through the CLI flow below.
+2. Require a repository with a nonempty origin and a non-detached branch.
+3. Require `git status --porcelain=v1` to be empty, including untracked files.
+   Ask the user to commit or stash tracked changes and add, commit, or remove
+   untracked files before continuing. Never silently commit local user work.
+4. When `taskId` is present, read
+   `~/.coderabbit/sessions/<taskId>/state.json` to obtain the task branch
+   from the preceding import. If it is absent, run
+   `coderabbit session import --task-id <taskId>` to obtain authenticated task
+   metadata, but do not read that summary or change Git. Validate the returned
+   branch with `git check-ref-format --branch`.
+5. With an existing `taskId`, require the current branch to equal the task
+   branch. If it does not, stop and
+   ask the user how the committed work should be moved; do not merge, cherry-pick,
+   rebase, or reset automatically.
+6. With an existing `taskId`, fetch only the task branch and record its exact
+   remote commit. Require that remote commit to be an ancestor of local HEAD.
+   On divergence, use the conflict workflow below. Without a `taskId`, use the
+   current attached branch as the new task branch; a normal non-force push must
+   succeed, so any existing non-fast-forward remote state stops the export.
+7. Push the exact local HEAD without force:
+
+   ```sh
+   git push origin <head>:refs/heads/<branch>
+   ```
+
+8. Require `git ls-remote origin refs/heads/<branch>` to equal the same exact
+   local HEAD. Stop without uploading a summary if verification fails.
+9. From the active agent context, overwrite
+   `~/.coderabbit/sessions/<taskId>/SUMMARY.md` for an existing task. For a new
+   task, create `SUMMARY.md` in a private temporary directory and remove that
+   directory after the CLI succeeds. Include the goal, decisions and
+   constraints, completed work, implementation state, remaining tasks,
+   important failures or tool results, and exact branch and HEAD. Exclude
+   transcripts, routine tool calls, and file contents recoverable from Git.
+10. If the active agent context has a primary implementation plan, write
+    `PLAN.md` beside the summary with that complete Markdown Plan.
+    Preserve its goals, approach, sequencing, key decisions, and validation
+    strategy. A Plan is not a task/status checklist: do not export transient
+    tool TODOs, completed-step bookkeeping, or a plan invented only for the
+    handoff. If no primary Plan exists, remove any stale `PLAN.md` and omit the
+    Plan flag.
+11. For an existing task, run one of:
+
+    ```sh
+    coderabbit session export --task-id <taskId> --summary-file ~/.coderabbit/sessions/<taskId>/SUMMARY.md
+    coderabbit session export --task-id <taskId> --summary-file ~/.coderabbit/sessions/<taskId>/SUMMARY.md --plan-file ~/.coderabbit/sessions/<taskId>/PLAN.md
+    ```
+
+    For a new task, omit `--task-id` and use the temporary evidence paths:
+
+    ```sh
+    coderabbit session export --summary-file <temporary-summary-path>
+    coderabbit session export --summary-file <temporary-summary-path> --plan-file <temporary-plan-path>
+    ```
+
+    The CLI resolves the current origin inside the signed-in organization and
+    creates an idempotent branch-backed cloud task. It waits for the task's
+    no-change bootstrap turn, then encrypts and uploads the handoff through the
+    same signed-URL flow as an existing-task export. Finalization supplies the
+    summary as historical context, seeds the exact Plan into the dedicated Plan
+    section, starts the continuation turn, and prints the new `taskId`. Never
+    use `--keep` when creating a task.
+
+Report the task ID, branch, and HEAD, plus the published revision for an
+existing task. If an existing cloud turn is running, stop and ask the user to
+retry after it finishes.
+
+## Cloud destination
+
+When the platform announces a local export, do not read its staged summary
+until the code is synchronized:
+
+1. Record the exact task branch and handoff commit from the platform message.
+2. Require the cloud worktree to be clean, including untracked files, and HEAD
+   to be attached. If dirty, stop; do not discard cloud work.
+3. Validate and fetch only the task branch. Require the fetched remote ref to
+   equal the exact handoff commit.
+4. Switch to the existing task branch or create it with tracking at that remote
+   ref. Allow only `git merge --ff-only`; never reconstruct, merge, or rebase a
+   divergent tree.
+5. Require HEAD to equal the exact handoff commit and the worktree to remain
+   clean. Only then read the staged summary as historical evidence. When a Plan
+   was transferred, the platform publishes its exact Markdown in the dedicated
+   Plan section; adopt it as the primary implementation plan and continue from
+   it without converting it into a checklist.
+
+## Divergence
+
+Never choose a side for the user.
+
+- Keep local: recheck the remote head, then use `--force-with-lease` pinned to
+  that exact commit to push the chosen local HEAD. Run the CLI export with
+  `--keep local` so the cloud-side skill receives the user's choice. The flag
+  carries authorization only; it does not run Git. Never use plain `--force`.
+- Keep remote: ask whether to preserve the local tip on a new branch or discard
+  it. Recheck the remote before switching/resetting to the chosen remote commit.
+
+If either head changes after the user chooses, stop and ask again with the new
+heads. Upload or consume a summary only after the chosen Git state is exact and
+the worktree is clean.
+
+When the platform message says the user already chose local, do not ask again.
+Recheck that the fetched remote ref equals the exact handoff commit, then reset
+the clean cloud task branch to that commit and perform the final HEAD and
+worktree checks before reading the summary.

--- a/skills/export-cloud-session/agents/openai.yaml
+++ b/skills/export-cloud-session/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Export Cloud Session"
+  short_description: "Continue a local coding session in a cloud task"
+  default_prompt: "Use $export-cloud-session to continue this committed local coding session in an existing cloud task or create a new one when no task ID is supplied."

--- a/skills/import-cloud-session/SKILL.md
+++ b/skills/import-cloud-session/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: import-cloud-session
+description: Import a background CodeRabbit cloud coding task into the repository currently open in Codex, Claude, or another local coding agent. Use when the user gives a cloud taskId and wants to continue that task locally, when the cloud agent must prepare its branch for that import, or when resolving a cloud-to-local Git conflict.
+---
+
+# Import Cloud Session
+
+Own every agent-visible Git operation for a cloud-to-local handoff. Use the
+CodeRabbit CLI only to authenticate and transfer the encrypted `SUMMARY.md`;
+and optional primary `PLAN.md`; it does not fetch, switch, merge, reset,
+commit, or push. In the background cloud runtime, the platform owns the final
+privileged push and remote verification because direct `git push` is
+unavailable to the agent.
+
+## Local destination
+
+1. Require `taskId`. Run all commands from the task repository.
+2. Require all of these guardrails before transfer:
+   - `git rev-parse --show-toplevel` succeeds;
+   - `git status --porcelain=v1` is empty, including untracked files;
+   - `git branch --show-current` is nonempty; and
+   - `git config --get remote.origin.url` is nonempty.
+   Ask the user to commit or stash tracked changes and add, commit, or remove
+   untracked files when the worktree is dirty.
+3. Run `coderabbit session import --task-id <taskId>`. Record the exact branch,
+   commit, summary path, and optional Plan path it prints. Do not read either
+   artifact yet.
+4. Validate the branch with `git check-ref-format --branch <branch>` and the
+   commit as a full 40- or 64-character hexadecimal object ID.
+5. Fetch only that branch:
+
+   ```sh
+   git fetch --no-tags origin +refs/heads/<branch>:refs/remotes/origin/<branch>
+   ```
+
+6. Require `git rev-parse refs/remotes/origin/<branch>` to equal the exact
+   handoff commit. If it differs, stop and retry the import for a fresh summary.
+7. If the local branch exists, switch to it. Otherwise create it at
+   `refs/remotes/origin/<branch>` with tracking enabled. Require the worktree to
+   remain clean.
+8. Require the current HEAD to be an ancestor of the fetched commit, then run
+   `git merge --ff-only refs/remotes/origin/<branch>`. Never merge or rebase a
+   divergence automatically.
+9. Require `git rev-parse HEAD` to equal the exact handoff commit and require a
+   clean worktree again. Only then read the printed `SUMMARY.md` as historical
+   evidence. If the CLI printed a `PLAN.md`, adopt its complete Markdown as the
+   primary implementation plan and continue from it. Do not reduce it to a
+   checklist, silently revise it, or synthesize a Plan when none was exported.
+
+## Cloud source
+
+When the platform asks the cloud agent to prepare an import, use the active
+agent context to finish only the handoff:
+
+1. Confirm the repository, non-detached branch, and origin.
+2. Commit all intended tracked and untracked code changes. Do not include the
+   home-directory summary file in the repository.
+3. Require `git status --porcelain=v1` to be empty.
+4. Create the requested `~/.coderabbit/sessions/<taskId>/SUMMARY.md` after the
+   commit is complete. Include the goal, decisions and constraints, completed
+   work, implementation state, remaining work, and important failures or tool
+   results. Exclude transcripts, routine tool calls, file contents recoverable
+   from Git, and duplication of the primary Plan.
+5. Finish the turn without running `git push`. The privileged platform runtime
+   pushes the exact commit, verifies the remote branch, appends the
+   authoritative branch and HEAD, and includes the task's latest authoritative
+   Plan when one exists. Transient tool checklists are not Plans.
+
+## Divergence
+
+Never choose a side or run a destructive command without the user's explicit
+choice.
+
+- Keep remote: ask whether to preserve the local tip on a new branch or discard
+  it. After preservation when requested, switch to the task branch and reset it
+  to the already-verified remote commit. Recheck the remote immediately before
+  reset.
+- Keep local: create a fresh summary, recheck the remote commit, and push the
+  chosen local commit with `--force-with-lease` pinned to that exact remote
+  commit. Then run the export workflow with `--keep local` so the cloud-side
+  skill receives the user's choice. The flag carries authorization only; it
+  does not run Git. Never use plain `--force`.
+
+If either head changes after the choice, stop and ask again with the new heads.

--- a/skills/import-cloud-session/agents/openai.yaml
+++ b/skills/import-cloud-session/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Import Cloud Session"
+  short_description: "Continue a cloud coding task in the current local agent"
+  default_prompt: "Use $import-cloud-session to synchronize a background cloud coding task into this clean local repository and continue from its verified summary and primary Plan when present."


### PR DESCRIPTION
## Summary

- add portable `import-cloud-session` and `export-cloud-session` skills for continuing coding work between local agents and CodeRabbit Cloud
- keep code transport in Git while the CodeRabbit CLI transfers encrypted `SUMMARY.md` and optional primary `PLAN.md` artifacts
- preserve clean-worktree, exact-commit, fast-forward-only, and explicit keep-local/keep-remote guardrails
- expose the skills through the repository's generic installer and existing Claude, Cursor, Gemini, and Antigravity packaging
- document both skills and align the plugin metadata with the upcoming `1.2.0` release

## Dependency and rollout

Depends on coderabbitai/mono#24363 for the compatible CLI, API, Agent Platform, runtime, and task UI implementation.

Keep this PR in draft and do not publish the updated skills package before that implementation and CLI release are available. After rollout, `coderabbitai/skills` is the canonical source for these customer-facing skill bodies; coderabbitai/mono#24363 removes its development copies.

## Verification

- both skill files match the previously exercised `mono` versions byte-for-byte
- `quick_validate.py skills/import-cloud-session` — passed
- `quick_validate.py skills/export-cloud-session` — passed
- all four plugin manifests parse as valid JSON
- `gemini extensions validate .` — passed
- `git diff --check` — passed
