### PR TITLE
docs: add public contribution guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Report incorrect behavior in a skill, command, agent, or packaged integration.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Do not include credentials or private repository information.
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - Portable skill
+        - Claude Code plugin
+        - Cursor plugin
+        - Gemini CLI extension
+        - Antigravity CLI plugin
+        - Codex plugin guidance
+        - Release archive
+        - Other public packaging
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: Provide the installed version, release tag, or commit SHA.
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and why it is incorrect.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction
+      description: Provide the smallest public reproduction, including the agent and relevant commands.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Public evidence
+      description: Link relevant public documentation and include redacted logs or screenshots when useful.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I removed credentials, private links, and private repository information.
+          required: true
+        - label: I searched existing issues for the same problem.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/coderabbitai/skills/security/advisories/new
+    about: Report repository vulnerabilities privately instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/skill-change.yml
+++ b/.github/ISSUE_TEMPLATE/skill-change.yml
@@ -1,0 +1,61 @@
+name: Skill or integration proposal
+description: Propose a new skill or a behavioral change to an existing agent integration.
+title: "[Proposal]: "
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem and user outcome
+      description: Describe the recurring user need and the result the change should make possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: agents
+    attributes:
+      label: Target agents and distribution surfaces
+      description: List every agent, plugin, command, manifest, or marketplace affected.
+    validations:
+      required: true
+
+  - type: textarea
+    id: sources
+    attributes:
+      label: Public authoritative references
+      description: Link the Agent Skills specification and current public host documentation that define the proposed behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: disclosure
+    attributes:
+      label: Progressive-disclosure design
+      description: Explain what belongs in SKILL.md and what will load on demand from focused references.
+    validations:
+      required: true
+
+  - type: textarea
+    id: deterministic
+    attributes:
+      label: Deterministic scripts, tools, and validation
+      description: Identify repeatable operations that should live in scripts or tools and how the result will be validated.
+    validations:
+      required: true
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and migration
+      description: Describe host-specific differences, existing users affected, and any migration or release implications.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: This proposal contains only public information and public references.
+          required: true
+        - label: I searched existing issues and pull requests for related work.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- What user outcome changes, and why? -->
+
+## Affected surfaces
+
+<!-- List canonical skills, commands, agents, manifests, docs, and distribution channels. -->
+
+## Public references
+
+<!-- Link authoritative specifications and current host documentation. -->
+
+## Validation
+
+<!-- List exact commands and results. State unavailable checks explicitly. -->
+
+## Checklist
+
+- [ ] `SKILL.md` stays focused on activation, routing, domain context, and workflow framing.
+- [ ] Detailed material uses focused references and progressive disclosure.
+- [ ] Repeatable deterministic operations use scripts or tools when practical.
+- [ ] Every referenced file, script, tool, command, and option exists.
+- [ ] Native commands, agents, manifests, docs, and distribution records remain aligned.
+- [ ] The change follows the Agent Skills specification, AGENTS.md open format, and current public guidance for every declared host.
+- [ ] The pull request contains no credentials, private links, private configuration, or private operational details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this repository are documented in this file.
 
 ### Added
 
+- Added public contribution guidance, structured issue forms, and a pull-request
+  template for agent-skill and integration changes.
 - Added native Gemini CLI extension packaging via `gemini-extension.json`,
   including the `/coderabbit:review` command and existing portable skills.
 - Added native Antigravity CLI plugin packaging via the repository-root

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing
+
+Thanks for helping improve CodeRabbit's public agent skills and plugin packaging.
+
+## Before You Start
+
+Open an issue before proposing a new skill, a new distribution channel, or a
+behavioral change that affects several supported agents. Small corrections can
+go directly to a pull request.
+
+Report security vulnerabilities through GitHub's private
+[Report a vulnerability](https://github.com/coderabbitai/skills/security/advisories/new)
+form, not through a public issue.
+
+## Repository Structure
+
+- `skills/` contains the canonical portable skills.
+- `commands/` and `agents/` contain native command and agent packaging that must
+  remain behaviorally aligned with the corresponding canonical skill.
+- `.claude-plugin/`, `.cursor-plugin/`, `gemini-extension.json`, and
+  `plugin.json` describe host-specific packaging.
+- `DISTRIBUTION_CHANNELS.md` records which channels are live, packaged, or still
+  in development.
+
+## Designing Agent Guidance
+
+Follow the [Agent Skills specification](https://agentskills.io/specification)
+and the [AGENTS.md open format](https://agents.md/), plus the current public
+documentation for every agent or plugin host named by the change.
+
+- Keep `SKILL.md` focused on activation, routing, domain context, and workflow
+  framing.
+- Use progressive disclosure: move details needed only in some workflows into
+  focused files under `references/` and say when to read each one.
+- Put repeatable deterministic operations in `scripts/` or tools when practical.
+- Keep referenced files one level from `SKILL.md` when possible, and verify that
+  every referenced file, command, option, and tool exists.
+- Explain host-specific behavior explicitly instead of assuming every agent has
+  the same filesystem, sandbox, authentication, or command model.
+- Update every affected native command, agent, manifest, README section, and
+  distribution record in the same pull request.
+
+## Validation
+
+Run the checks that match your change:
+
+```bash
+git diff --check
+jq empty .claude-plugin/plugin.json .cursor-plugin/plugin.json gemini-extension.json plugin.json
+```
+
+When changing `.coderabbit.yaml`, also run:
+
+```bash
+coderabbit config validate .coderabbit.yaml
+```
+
+When changing host-specific packaging, run its official validator when
+available, including `gemini extensions validate .` or
+`agy plugin validate .`.
+
+Include the exact commands and results in the pull-request description. If a
+validator is unavailable, state that clearly instead of claiming it passed.
+
+## Pull Requests
+
+- Keep each pull request centered on one reviewable outcome.
+- Link the issue or public authoritative documentation that establishes the
+  behavior being changed.
+- Call out every supported distribution surface affected by the change.
+- Do not include credentials, private links, private configuration, or private
+  operational details.
+- Resolve review comments and keep the branch current until required checks and
+  maintainer approval pass on the latest commit.
+
+By contributing, you agree that your contribution is licensed under this
+repository's [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- add public contribution guidance for canonical skills and host-specific packaging
- add structured bug-report and skill-change issue forms
- disable blank public issues and route vulnerability reports to GitHub private advisories
- add a pull-request template aligned with progressive disclosure and deterministic tooling

## Why

This public repository distributes skills across several agent hosts. Contributors need a public, reviewable contract for source ownership, host alignment, validation, privacy, and focused changes.

## Validation

- `git diff --check`
- parsed every issue-form YAML file successfully with Ruby YAML
- verified the Agent Skills, AGENTS.md, and GitHub private-reporting references
- verified GitHub private vulnerability reporting is enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contribution guidance, including issue reporting, security reporting, validation, packaging checks, and pull-request expectations.
  * Documented public contribution updates in the unreleased changelog.

* **New Features**
  * Added structured templates for bug reports, skill-change proposals, and pull requests.
  * Added issue configuration with a private security-reporting option and disabled blank issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->