### PR TITLE
ci: align approver gate with CODEOWNERS

### DIFF
--- a/.github/workflows/required-approver.yml
+++ b/.github/workflows/required-approver.yml
@@ -22,7 +22,7 @@ jobs:
     name: verify
     runs-on: ubuntu-latest
     env:
-      REQUIRED_APPROVERS: nehal-a2z,juanpflores
+      REQUIRED_APPROVERS: nehal-a2z,juanpflores,esthor
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       REPOSITORY: ${{ github.repository }}
@@ -85,7 +85,8 @@ jobs:
           )"
 
           if [[ -z "$approved_by" ]]; then
-            echo "::error::This PR needs an approval from nehal-a2z or juanpflores on the latest head commit."
+            required_display="${REQUIRED_APPROVERS//,/ or }"
+            echo "::error::This PR needs an approval from ${required_display} on the latest head commit."
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this repository are documented in this file.
 
 ### Changed
 
+- Aligned the required-approver check with the repository-wide CODEOWNERS.
 - Aligned the shared code-review subagent metadata with Gemini CLI's schema.
 - Removed alternate detailed-output guidance so review agents use `--agent`
   exclusively.


### PR DESCRIPTION
## Summary

- recognize every repository-wide CODEOWNER in the existing required-approver check
- derive the failure message from the configured approver list so the check and its guidance cannot disagree
- document the governance alignment in the changelog

## Why

The repository-wide CODEOWNERS entry now includes `@esthor`, but the `verify` workflow still accepted approvals from only `@nehal-a2z` or `@juanpflores`. Requiring that check in the default-branch ruleset without this update would reject an otherwise valid latest-head CODEOWNER approval.

## Validation

- workflow YAML parses successfully
- the complete embedded Bash step passes `bash -n`
- `git diff --check`

This PR does not change repository settings or merge any pull request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Workflow Updates**
  - Required approval checks now include an additional designated approver.
  - Missing-approval messages automatically reflect the current required approver list, making outstanding approvals clearer.
  - Approval validation is now aligned with the repository’s configured ownership requirements.

- **Documentation**
  - Updated the changelog to record the latest approval-check alignment and expanded approver coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->