### PR TITLE
Record completed Claude marketplace migration

### DIFF
--- a/DISTRIBUTION_CHANNELS.md
+++ b/DISTRIBUTION_CHANNELS.md
@@ -1,6 +1,6 @@
 # Distribution Channels
 
-Last verified: 2026-08-04
+Last verified: 2026-08-12
 
 This file is the repository's operating inventory for where CodeRabbit skills and adjacent agent integrations are distributed. Public user-facing install guidance belongs in `README.md`; in-development and maintainer-only channels should stay here until they are ready to launch.
 
@@ -10,7 +10,7 @@ This file is the repository's operating inventory for where CodeRabbit skills an
 | --- | --- | --- | --- |
 | Skills package (`npx skills add coderabbitai/skills`) | Live | `README.md`, `skills/` | Canonical multi-agent distribution path for 35+ skills-compatible agents. |
 | Tagged GitHub release archive for binary installers | In development, not user-facing | `.github/workflows/release.yml` | Workflow publishes a versioned tarball, SHA-256 file, and release manifest on `v*` tags, but this channel is not part of public install guidance yet. |
-| Claude Code plugin marketplace | Live, source migration pending | `.claude-plugin/plugin.json`, `commands/`, `agents/` | In-repo packaging is active; official marketplace source is being moved from `coderabbitai/claude-plugin` to this repository. |
+| Claude Code plugin marketplace | Live | `.claude-plugin/plugin.json`, `commands/`, `agents/` | Official marketplace source. Migration from the legacy `coderabbitai/claude-plugin` repository completed on 2026-05-01. |
 | Cursor native plugin marketplace | Repo-packaged, publication should be verified | `.cursor-plugin/plugin.json` | Repo contains marketplace manifest; treat public listing as separate verification work. |
 | Gemini CLI native extension | Repo-packaged, release pending | `gemini-extension.json`, `skills/`, `commands/coderabbit/review.toml`, `agents/` | Publish direct installation after `v1.2.0`; verify gallery listing separately. |
 | Antigravity CLI native plugin | GitHub-installable | `plugin.json`, `skills/` | Install directly with `agy plugin install https://github.com/coderabbitai/skills`; treat marketplace publication as separate verification work. |


### PR DESCRIPTION
## Summary

Mark the completed Claude Code marketplace migration as live and explicitly name `coderabbitai/skills` as its source. The inventory still described the move from `coderabbitai/claude-plugin` as pending.

## Affected surfaces

- `DISTRIBUTION_CHANNELS.md`: Claude Code marketplace status, source, migration note, and the original inventory verification date.
- This is a documentation-only change; installation commands and plugin packaging remain aligned with the existing README and manifests.

## Public references

- [Official marketplace manifest](https://github.com/anthropics/claude-plugins-official/blob/main/.claude-plugin/marketplace.json): the CodeRabbit entry points to `https://github.com/coderabbitai/skills.git`.
- [Marketplace source migration](https://github.com/anthropics/claude-plugins-official/pull/1629).
- [Current marketplace pin update](https://github.com/anthropics/claude-plugins-official/pull/6091).

## Validation

- `git diff --check origin/main...HEAD` — passed.
- `git diff --stat origin/main...HEAD` — only `DISTRIBUTION_CHANNELS.md`, two insertions and two deletions.
- Rechecked the official marketplace manifest on 2026-09-16 through the GitHub API: source is `coderabbitai/skills`, pinned to `929b0ec6dae6871abf20f78e7e502d6b836e1379`.
- Updated the branch with current `main`; CodeRabbit reviewed head `8a6e6f65f75f807106e9117703be29ac2bdf12b2` with no actionable code comments.
- Runtime, packaging, and agent-guidance validators are not applicable to this inventory-only edit.

## Checklist

- [x] `SKILL.md` stays focused on activation, routing, domain context, and workflow framing — unchanged.
- [x] Detailed material uses focused references and progressive disclosure — no guidance changes.
- [x] Repeatable deterministic operations use scripts or tools when practical — no new operations.
- [x] Every referenced file, script, tool, command, and option exists.
- [x] Native commands, agents, manifests, docs, and distribution records remain aligned.
- [x] The change follows the Agent Skills specification, AGENTS.md open format, and current public guidance for every declared host — no skill or host behavior changes; the marketplace source was verified.
- [x] The pull request contains no credentials, private links, private configuration, or private operational details.
